### PR TITLE
Reduce star cap from 2000 to 250 in scoring algorithm

### DIFF
--- a/scripts/score.js
+++ b/scripts/score.js
@@ -16,7 +16,7 @@ const STAR_WEIGHT = 2;
 // 3.125 is the exact average of the new individual weights (5 + 4 + 2 + 1.5 = 12.5 / 4)
 const FALLBACK_ACTIVITY_WEIGHT = 3.125;
 const SIX_MONTHS_DAYS = 180;
-const MAX_STARS_FOR_SCORING = 2000;
+const MAX_STARS_FOR_SCORING = 250;
 
 function daysSince(date) {
   if (!date) {


### PR DESCRIPTION
## Description

This PR reduces the star cap in the scoring algorithm from 2,000 to 250 stars. This prevents developers with extremely popular repositories from dominating the leaderboard.

## Changes

- **scripts/score.js**: Updated `MAX_STARS_FOR_SCORING` constant from `2000` to `250` 

## Why This Matters

The previous star cap of 2,000 allowed a single extremely popular repository to heavily skew a developer's ranking score. By reducing this cap to 250, we ensure a more balanced leaderboard that better represents consistent, ongoing activity across multiple projects.

## Note

This is a **temporary solution** to address ranking fairness. A more comprehensive scoring algorithm overhaul is requested to better balance all ranking factors and would provide a complete solution.

## Testing

The new star cap will be applied immediately to all future scoring calculations during the next batch run. Developers with more than 250 stars will have their star contribution capped at 250 in the ranking formula.

---

**Related Issue**: #13