### PR TITLE
docs(about): sync scoring metrics and caps with latest algorithm

### DIFF
--- a/src/pages/About.jsx
+++ b/src/pages/About.jsx
@@ -1,9 +1,9 @@
 import React, { useState } from 'react';
 
 const SCORING_WEIGHTS = [
-  { field: 'Stars', weight: '× 2', note: 'Capped at 2,000 to prevent outlier dominance' },
-  { field: 'Events (30d)', weight: '× 3', note: 'Meaningful contributions in the last 30 days' },
-  { field: 'Followers', weight: '× 1', note: 'Community reach' },
+  { field: 'Stars', weight: '× 2', note: 'Capped at 250 to prevent outlier dominance' },
+  { field: 'Activity (30d)', weight: 'Dynamic', note: 'Releases (5), PRs (4), Pushes (2), Issues (1.5)' },
+  { field: 'Followers', weight: '× 1', note: 'Capped at 500 to prevent outlier dominance' },
   { field: 'Public Repos', weight: '× 0.5', note: 'Breadth of open-source work' },
 ];
 
@@ -79,7 +79,7 @@ const FAQ = [
   { q: 'How often is the leaderboard updated?', a: 'Every hour. An external cron service triggers the GitHub Actions workflow 24 times per day — one batch per hour. A full cycle through all developers completes in 24 hours.' },
   { q: 'Why am I not on the leaderboard?', a: 'You need at least 30 meaningful contributions in the last 60 days, no gap longer than 30 days, an account older than 30 days, more than 3 public repos, and more than 1 follower. Your GitHub profile must also include "Pakistan" in the location field.' },
   { q: 'What counts as a "meaningful" contribution?', a: 'Only PushEvents, PullRequestEvents, IssuesEvents, and ReleaseEvents. Starring repos, forking, watching, or commenting do not count toward the contribution threshold.' },
-  { q: 'Why is my score lower than expected?', a: 'Stars are capped at 2,000 for scoring purposes. Accounts younger than 6 months receive a 0.5× penalty on their entire score. The score also weighs recent 30-day activity heavily (3× multiplier).' },
+  { q: 'Why is my score lower than expected?', a: 'Stars are capped at 250 and followers are capped at 500 for scoring purposes. Accounts younger than 6 months receive a 0.5× penalty on their entire score. The score also weighs recent 30-day activity heavily.' },
   { q: 'What is the "new account penalty"?', a: 'If your GitHub account is less than 6 months old, your final score is halved (multiplied by 0.5). This prevents newly created accounts from dominating the board.' },
   { q: 'How does the scanner work at scale?', a: 'Rankistan runs a rolling daily scanner from year 2000 to present. It scans 40,000+ profiles, re-evaluates 20,000+ candidates for score changes, then applies strict activity gates before ranking.' },
   { q: 'How does AI summary generation work?', a: 'It is on-demand only. Expanding a card triggers a request to the Cloudflare Worker, which rate-limits and sanitizes input, calls Groq, validates output, and returns a cached summary per username.' },
@@ -246,7 +246,7 @@ export default function About() {
 
             <div className="bg-surface-container-low border border-outline-variant p-5 mb-6 font-mono text-sm leading-relaxed">
               <div className="text-primary">
-                base_score = (stars × 2) + (events_30d × 3) + (followers × 1) + (public_repos × 0.5)
+                base_score = (stars × 2) + (activity_score) + (followers × 1) + (public_repos × 0.5)
               </div>
               <div className="text-tertiary mt-2">
                 final_score = base_score × (account_age &lt; 6mo ? 0.5 : 1.0)
@@ -267,7 +267,7 @@ export default function About() {
               <span className="font-mono text-[10px] text-tertiary uppercase tracking-widest">Penalty Notice</span>
               <p className="font-body text-xs text-outline leading-relaxed mt-1">
                 Accounts younger than <span className="text-on-surface font-bold">6 months</span> receive a <span className="text-on-surface font-bold">0.5×</span> multiplier.
-                Stars are capped at <span className="text-on-surface font-bold">2,000</span> before the weight is applied.
+                Stars are capped at <span className="text-on-surface font-bold">250</span> and followers at <span className="text-on-surface font-bold">500</span> before weights are applied.
               </p>
             </div>
           </div>


### PR DESCRIPTION
## Description
This PR synchronizes the scoring documentation on the `About` page to accurately match the actual scoring algorithm defined in the `README`. 

## Changes Included
- Updated the `SCORING_WEIGHTS` list to reflect the current caps (Stars capped at 250, Followers capped at 500).
- Updated the activity score weight to clarify dynamic weighting for 30-day activity (Releases, PRs, Pushes, Issues).
- Corrected the Penalty Notice and FAQ answers to reflect the updated 250/500 threshold caps instead of the old 2,000 cap.