### PR TITLE
Add atomic write + dry-run mode for incremental pipeline

### DIFF
--- a/scripts/run-all.js
+++ b/scripts/run-all.js
@@ -1,14 +1,15 @@
-'use strict';
+"use strict";
 
-const fs = require('node:fs');
-const path = require('node:path');
+const fs = require("node:fs");
+const path = require("node:path");
 
-const PUBLIC_DIR = path.join(process.cwd(), 'public');
-const DATA_JSON = path.join(PUBLIC_DIR, 'data.json');
+const PUBLIC_DIR = path.join(process.cwd(), "public");
+const DATA_JSON = path.join(PUBLIC_DIR, "data.json");
+const DRY_RUN_DATA_JSON = path.join(PUBLIC_DIR, "data.dry-run.json");
 
-function loadExistingLeaderboard() {
+function loadExistingLeaderboard(targetPath = DATA_JSON) {
   try {
-    const raw = fs.readFileSync(DATA_JSON, 'utf8');
+    const raw = fs.readFileSync(targetPath, "utf8");
     const data = JSON.parse(raw);
     return Array.isArray(data.leaderboard) ? data.leaderboard : [];
   } catch {
@@ -16,28 +17,110 @@ function loadExistingLeaderboard() {
   }
 }
 
-async function runIncremental(batchIndex) {
+/**
+ * Atomically writes JSON by staging it in a temp file first, validating it,
+ * and then renaming it over the live target.
+ *
+ * This avoids exposing a partially written or corrupt JSON file to the frontend.
+ */
+function atomicWriteJsonSync(targetPath, value) {
+  const tmpPath = `${targetPath}.tmp`;
+
+  try {
+    const json = JSON.stringify(value);
+
+    // Write to a staging file in the same directory so rename stays atomic
+    // on the same filesystem.
+    fs.writeFileSync(tmpPath, json, "utf8");
+
+    // Validate the staged file before promoting it to the live path.
+    JSON.parse(fs.readFileSync(tmpPath, "utf8"));
+
+    fs.renameSync(tmpPath, targetPath);
+  } catch (error) {
+    try {
+      if (fs.existsSync(tmpPath)) {
+        fs.unlinkSync(tmpPath);
+      }
+    } catch {
+      // Best-effort cleanup only; preserve the original failure.
+    }
+
+    throw error;
+  }
+}
+
+function buildDryRunOutput(batchIndex, maxDevelopers) {
+  // Dry-run mode avoids GitHub entirely. It reuses the current local leaderboard
+  // as test data so we can verify JSON generation and atomic writes safely.
+  const existing = loadExistingLeaderboard(DATA_JSON);
+
+  let leaderboard =
+    existing.length > 0
+      ? existing.map((d, i) => ({
+          ...d,
+          batch_index: typeof d.batch_index === "number" ? d.batch_index : batchIndex,
+          rank: i + 1,
+        }))
+      : [
+          {
+            username: "dry-run-user",
+            score: 0,
+            batch_index: batchIndex,
+            rank: 1,
+          },
+        ];
+
+  leaderboard = leaderboard.slice(0, maxDevelopers);
+  leaderboard.forEach((d, i) => {
+    d.rank = i + 1;
+  });
+
+  return {
+    last_updated: new Date().toISOString(),
+    total_devs: leaderboard.length,
+    leaderboard,
+  };
+}
+
+async function runIncremental(batchIndex, { dryRun = false } = {}) {
   const {
     fetchPakistaniDevelopers,
     applyActivityFilter,
     SEARCH_BATCHES,
     MAX_DEVELOPERS,
-    ACTIVITY_THRESHOLDS
-  } = require('./fetch-devs.js');
-  const { scoreDevelopers } = require('./score.js');
-  const { stripInternalFields } = require('./write-leaderboard.js');
+    ACTIVITY_THRESHOLDS,
+  } = require("./fetch-devs.js");
+  const { scoreDevelopers } = require("./score.js");
+  const { stripInternalFields } = require("./write-leaderboard.js");
 
   if (batchIndex < 0 || batchIndex >= SEARCH_BATCHES.length) {
-    console.error(`Invalid batch index: ${batchIndex}. Must be 0-${SEARCH_BATCHES.length - 1}.`);
+    console.error(
+      `Invalid batch index: ${batchIndex}. Must be 0-${SEARCH_BATCHES.length - 1}.`,
+    );
     process.exit(1);
   }
 
-  console.log(`\n=== Incremental batch ${batchIndex}: ${SEARCH_BATCHES[batchIndex].label} ===\n`);
+  const targetPath = dryRun ? DRY_RUN_DATA_JSON : DATA_JSON;
+
+  console.log(
+    `\n=== Incremental batch ${batchIndex}: ${SEARCH_BATCHES[batchIndex].label} ===\n`,
+  );
+
+  if (dryRun) {
+    console.log(`DRY RUN: skipping GitHub fetch and writing to ${targetPath}`);
+    const output = buildDryRunOutput(batchIndex, MAX_DEVELOPERS);
+    atomicWriteJsonSync(targetPath, output);
+    console.log(
+      `\nDry-run output written: ${output.total_devs} developers (capped at ${MAX_DEVELOPERS}).`,
+    );
+    return;
+  }
 
   const rawDevs = await fetchPakistaniDevelopers({
     repoRoot: process.cwd(),
     batchIndex,
-    rawOnly: true
+    rawOnly: true,
   });
 
   console.log(`Fetched ${rawDevs.length} raw developers.`);
@@ -45,8 +128,8 @@ async function runIncremental(batchIndex) {
   const filtered = applyActivityFilter(rawDevs);
   console.log(
     `Activity filter: ${rawDevs.length} -> ${filtered.length} passed ` +
-    `(>=${ACTIVITY_THRESHOLDS.MIN_CONTRIBUTIONS_60D} contributions in 60d, ` +
-    `<=${ACTIVITY_THRESHOLDS.MAX_INACTIVITY_GAP_DAYS}d max gap)`
+      `(>=${ACTIVITY_THRESHOLDS.MIN_CONTRIBUTIONS_60D} contributions in 60d, ` +
+      `<=${ACTIVITY_THRESHOLDS.MAX_INACTIVITY_GAP_DAYS}d max gap)`,
   );
 
   const scored = scoreDevelopers(filtered);
@@ -54,48 +137,66 @@ async function runIncremental(batchIndex) {
 
   const newEntries = scored.map((d) => ({
     ...stripInternalFields(d),
-    batch_index: batchIndex
+    batch_index: batchIndex,
   }));
 
-  const existing = loadExistingLeaderboard();
+  const existing = loadExistingLeaderboard(DATA_JSON);
   const kept = existing.filter((d) => d.batch_index !== batchIndex);
-  console.log(`Existing leaderboard: ${existing.length} total, ${kept.length} kept (removed ${existing.length - kept.length} from batch ${batchIndex}).`);
+  console.log(
+    `Existing leaderboard: ${existing.length} total, ${kept.length} kept ` +
+      `(removed ${existing.length - kept.length} from batch ${batchIndex}).`,
+  );
 
-  const map = new Map(kept.map((d) => [String(d.username || '').toLowerCase(), d]));
+  const map = new Map(
+    kept.map((d) => [String(d.username || "").toLowerCase(), d]),
+  );
   for (const dev of newEntries) {
-    map.set(String(dev.username || '').toLowerCase(), dev);
+    map.set(String(dev.username || "").toLowerCase(), dev);
   }
 
   let leaderboard = [...map.values()];
   leaderboard.sort((a, b) => {
     const diff = (b.score || 0) - (a.score || 0);
-    return diff !== 0 ? diff : String(a.username || '').localeCompare(String(b.username || ''));
+    return diff !== 0
+      ? diff
+      : String(a.username || "").localeCompare(String(b.username || ""));
   });
   leaderboard = leaderboard.slice(0, MAX_DEVELOPERS);
-  leaderboard.forEach((d, i) => { d.rank = i + 1; });
+  leaderboard.forEach((d, i) => {
+    d.rank = i + 1;
+  });
 
   const output = {
     last_updated: new Date().toISOString(),
     total_devs: leaderboard.length,
-    leaderboard
+    leaderboard,
   };
 
-  fs.writeFileSync(DATA_JSON, JSON.stringify(output));
-  console.log(`\nLeaderboard updated: ${leaderboard.length} developers (capped at ${MAX_DEVELOPERS}).`);
-  console.log(`Added ${newEntries.length} from batch ${batchIndex}, kept ${kept.length} from other batches.`);
+  atomicWriteJsonSync(targetPath, output);
+
+  console.log(
+    `\nLeaderboard updated: ${leaderboard.length} developers (capped at ${MAX_DEVELOPERS}).`,
+  );
+  console.log(
+    `Added ${newEntries.length} from batch ${batchIndex}, kept ${kept.length} from other batches.`,
+  );
 }
 
 const args = process.argv.slice(2);
 const mode = args[0];
+const dryRun = args.includes("--dry-run") || process.env.SKIP_GITHUB === "true";
 
-if (mode === '--incremental') {
+if (mode === "--incremental") {
   const idx = parseInt(args[1], 10);
   if (Number.isNaN(idx)) {
-    console.error('Usage: node scripts/run-all.js --incremental <batch-index>');
+    console.error("Usage: node scripts/run-all.js --incremental <batch-index> [--dry-run]");
     process.exit(1);
   }
-  runIncremental(idx).catch((e) => { console.error(e.message); process.exit(1); });
+  runIncremental(idx, { dryRun }).catch((e) => {
+    console.error(e.message);
+    process.exit(1);
+  });
 } else {
-  console.error('Usage: node scripts/run-all.js --incremental <batch-index>');
+  console.error("Usage: node scripts/run-all.js --incremental <batch-index> [--dry-run]");
   process.exit(1);
 }


### PR DESCRIPTION
# Fix atomic write for `public/data.json` and add dry-run mode

Fixes #23

## Summary
This PR fixes a production-risk issue in the incremental leaderboard pipeline where `public/data.json` was being written directly in place. If the process is interrupted or fails during the write, the file can be left empty or corrupted, which can break the leaderboard and map for users.

## What changed
- Replaced the direct `fs.writeFileSync(DATA_JSON, JSON.stringify(output))` write with an atomic write flow:
  - write JSON to a temporary file first
  - validate the temporary file by parsing it back
  - rename the temporary file over `public/data.json`
- Added cleanup for temporary files if the write fails
- Added `--dry-run` / `SKIP_GITHUB=true` support so the incremental pipeline can be tested without using a GitHub token or consuming API rate limits
- In dry-run mode, the pipeline writes to `public/data.dry-run.json` instead of the live production file

## Why this matters
`public/data.json` is the main data source for the frontend leaderboard and map. A partial or corrupted write can cause:
- broken leaderboard rendering for fresh visitors
- missing map statistics
- invalid JSON errors in the frontend
- a bad deploy that ships broken data to production

This change ensures the previous valid file remains intact unless the new file is fully written and valid.

## Testing
- [X] Ran the incremental pipeline in dry-run mode:
  - `node scripts/run-all.js --incremental 0 --dry-run`
- [X] Verified the output JSON is valid:
  - `node -e "const fs=require('node:fs'); const d=JSON.parse(fs.readFileSync('public/data.dry-run.json','utf8')); console.log('ok', d.total_devs, d.leaderboard.length)"`
- [X] Confirmed the temporary file is cleaned up after write:
  - `test ! -e public/data.dry-run.json.tmp && echo "tmp cleaned up"`
- [X] Confirmed the dry-run path works without GitHub access or a PAT
- [X] Verified the live `public/data.json` remains valid after the atomic-write flow

## Notes
- The production incremental path remains unchanged except for the safer atomic write behavior.
- Dry-run mode is meant for local verification and avoids rate-limit usage during testing.
