### PR TITLE
fix: dev-map hero layout fixed on larger screens

### DIFF
--- a/src/pages/DevMap.jsx
+++ b/src/pages/DevMap.jsx
@@ -401,7 +401,7 @@ export default function DevMap() {
         <div className="flex items-center justify-center h-96">
           <span className="font-mono text-sm text-tertiary animate-pulse uppercase tracking-widest">Loading Geo Data...</span>
         </div>
-      </main>
+      </main> 
     );
   }
 
@@ -409,7 +409,7 @@ export default function DevMap() {
     <main className="min-h-screen relative overflow-hidden">
       <div className="absolute inset-0 grid-lines pointer-events-none"></div>
       {/* Hero */}
-      <div className="max-w-6xl mx-auto px-4 pt-6 pb-6 sm:px-6 sm:pt-8 sm:pb-8 md:pt-12 md:pb-10 relative z-10">
+      <div className="max-w-[1440px] mx-auto px-4 pt-6 pb-6 sm:px-6 sm:pt-8 sm:pb-8 md:pt-12 md:pb-10 relative z-10">
         <div className="border-l-4 border-primary pl-4 sm:pl-6 flex flex-col md:flex-row justify-between items-start md:items-end gap-4 sm:gap-6">
           <div className="min-w-0">
             <h1 className="font-headline text-3xl sm:text-4xl md:text-5xl font-extrabold tracking-tighter uppercase text-on-surface mb-2">


### PR DESCRIPTION
## Fixed the Dev Map hero section layout issue on larger screens.

Previously, the hero section on dev map page appeared slightly shrunk on large displays, causing inconsistent alignment compared to other pages. Updated the layout width and spacing to ensure proper alignment and a more consistent responsive appearance across large screen sizes.

## Screenshots

- Before Fix
<img width="1307" height="849" alt="1st-map" src="https://github.com/user-attachments/assets/e6b9ce9b-9ad8-480c-8d8b-af93570579ac" />

- After Fix
<img width="1287" height="856" alt="2nd-map" src="https://github.com/user-attachments/assets/32639dd8-d65d-4878-a69a-f8992154671a" />
