### PR TITLE
feat(leaderboard): make full row clickable and add inline GitHub icon

### DIFF
--- a/src/components/DevCard.jsx
+++ b/src/components/DevCard.jsx
@@ -2,6 +2,12 @@ import React, { useEffect, useState } from 'react';
 import { normalizeLocationForDisplay } from '../utils/location';
 import { resolveHeatmapApiUrl, resolveHeatmapDirectUrl } from '../utils/groq.js';
 
+const GitHubIcon = ({ size = 16 }) => (
+  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" width={size} height={size} aria-hidden="true">
+    <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/>
+  </svg>
+);
+
 function ContributionHeatmap({ username }) {
   const [src, setSrc] = useState('');
   const [failed, setFailed] = useState(false);
@@ -64,13 +70,15 @@ export default function DevCard({ dev, onGenerateSummary, onGenerateBadge, summa
   ];
 
   const toggleExpand = async () => {
-    setIsExpanded(!isExpanded);
-    if (!isExpanded && !summary) {
+    const wasCollapsed = !isExpanded;
+    setIsExpanded(prev => !prev);
+    if (wasCollapsed && !summary) {
       await onGenerateSummary(dev);
     }
   };
 
   const username = dev?.username || '';
+  const githubUrl = `https://github.com/${username}`;
   const avatar = dev?.avatar || `https://avatars.githubusercontent.com/${username}`;
   const cleanLocation = normalizeLocationForDisplay(dev?.location);
   const linkedinUrl = typeof dev?.linkedin_url === 'string' ? dev.linkedin_url.trim() : '';
@@ -79,7 +87,7 @@ export default function DevCard({ dev, onGenerateSummary, onGenerateBadge, summa
   return (
     <div className="border-b border-outline-variant">
       {/* Main Row Info */}
-      <div className="grid grid-cols-1 md:grid-cols-12 md:gap-x-4 bg-surface items-center py-6 px-6 group hover:bg-surface-container-low transition-colors">
+      <div className="grid grid-cols-1 md:grid-cols-12 md:gap-x-4 bg-surface items-center py-6 px-6 group hover:bg-surface-container-low transition-colors cursor-pointer" onClick={toggleExpand}>
         <div className="col-span-full md:col-span-1 mb-2 md:mb-0">
           <span className="font-mono text-2xl font-bold text-outline-variant group-hover:text-primary transition-colors">
             {String(dev.rank).padStart(3, '0')}
@@ -116,8 +124,18 @@ export default function DevCard({ dev, onGenerateSummary, onGenerateBadge, summa
             <div className="whitespace-nowrap text-left font-mono font-bold text-tertiary tabular-nums md:col-span-1 md:flex md:justify-end md:text-right">
               {dev.score?.toLocaleString() || 0}
             </div>
-            <div className="flex shrink-0 justify-end md:col-span-1">
-              <button type="button" onClick={toggleExpand} className="text-outline hover:text-primary transition-colors" aria-expanded={isExpanded} aria-label={isExpanded ? 'Collapse details' : 'Expand details'}>
+            <div className="flex shrink-0 items-center gap-2 justify-end md:col-span-1">
+              <a
+                href={githubUrl}
+                target="_blank"
+                rel="noreferrer"
+                onClick={(e) => e.stopPropagation()}
+                aria-label={`${username} on GitHub`}
+                className="text-outline hover:text-primary transition-colors"
+              >
+                <GitHubIcon />
+              </a>
+              <button type="button" onClick={(e) => { e.stopPropagation(); toggleExpand(); }} className="text-outline hover:text-primary transition-colors" aria-expanded={isExpanded} aria-label={isExpanded ? 'Collapse details' : 'Expand details'}>
                 <span className="material-symbols-outlined">{isExpanded ? 'expand_less' : 'unfold_more'}</span>
               </button>
             </div>
@@ -177,7 +195,7 @@ export default function DevCard({ dev, onGenerateSummary, onGenerateBadge, summa
                 </div>
               </div>
               <div className="mt-6 grid grid-cols-1 sm:grid-cols-3 gap-4">
-                <a href={`https://github.com/${username}`} target="_blank" rel="noreferrer" className="text-center bg-surface-container-high border border-outline-variant py-2.5 font-mono text-[10px] uppercase hover:text-primary transition-all active:translate-y-px">
+                <a href={githubUrl} target="_blank" rel="noreferrer" className="text-center bg-surface-container-high border border-outline-variant py-2.5 font-mono text-[10px] uppercase hover:text-primary transition-all active:translate-y-px">
                   View GitHub
                 </a>
                 {hasLinkedin ? (


### PR DESCRIPTION
- Row div gets onClick + cursor-pointer; expand button and GitHub link use
  stopPropagation to prevent double-firing
- GitHub icon link (inline SVG) added on collapsed row next to expand button
- Extract GitHubIcon to module-level component; consolidate githubUrl const
- Fix stale isExpanded closure in toggleExpand (functional updater + snapshot)
Closes #39