### PR TITLE
fix(badge): make rank badge self-identifying and verifiable (#52)

### DIFF
--- a/cloudflare/worker.js
+++ b/cloudflare/worker.js
@@ -407,7 +407,7 @@ async function handleBadgeRequest(request, env) {
 
     return new Response(JSON.stringify({
       schemaVersion: 1,
-      label: 'Rankistan',
+      label: `Rankistan @${dev.username}`,
       message: `rank #${dev.rank}`,
       color: '1a7f4e',
       labelColor: '0f6e56',

--- a/src/pages/BadgeGenerator.jsx
+++ b/src/pages/BadgeGenerator.jsx
@@ -29,7 +29,7 @@ function buildBadgeUrl(username, style) {
 
 function getSnippet(style, username, fmt) {
   const img = buildBadgeUrl(username, style);
-  const link = "https://rankistan.dev";
+  const link = `https://rankistan.dev/#${encodeURIComponent(username)}`;
   const alt = "Rankistan rank badge";
   if (fmt === "md") return `[![${alt}](${img})](${link})`;
   if (fmt === "html")


### PR DESCRIPTION
Addresses #52 (badge can be faked).

**Two root causes, two fixes:**
1. **Not self-identifying** — the badge showed only `Rankistan | rank #N`, so a copied badge looked like the displayer's own rank. Worker now returns `label: "Rankistan @<username>"` → renders **`Rankistan @alice | rank #1`**. A copied badge visibly shows it belongs to `@alice`.
2. **No verification link** — the snippet linked to the generic leaderboard. It now links to **`https://rankistan.dev/#<username>`**, the per-user page. (This deep-link target is activated by #42.)

**Notes:**
- Honest mitigation, not a hermetic lock — hand-crafted static Shields badges can't be prevented.
- The Worker change requires `npm run cf:deploy` to go live (the frontend snippet change ships with the normal Pages deploy).

Closes #52