### PR TITLE
fix(leaderboard): use avatar_url for DevCard avatars (#37)

### DIFF
--- a/src/components/DevCard.jsx
+++ b/src/components/DevCard.jsx
@@ -79,7 +79,7 @@ export default function DevCard({ dev, onGenerateSummary, onGenerateBadge, summa
 
   const username = dev?.username || '';
   const githubUrl = `https://github.com/${username}`;
-  const avatar = dev?.avatar || `https://avatars.githubusercontent.com/${username}`;
+  const avatar = dev?.avatar_url || dev?.avatar || `https://github.com/${username}.png?size=80`;
   const cleanLocation = normalizeLocationForDisplay(dev?.location);
   const linkedinUrl = typeof dev?.linkedin_url === 'string' ? dev.linkedin_url.trim() : '';
   const hasLinkedin = linkedinUrl !== '';


### PR DESCRIPTION
`DevCard` read `dev.avatar`, but the pipeline writes **`avatar_url`** (verified: all 1000 rows have `avatar_url`, 0 have `avatar`). So every avatar fell through to `https://avatars.githubusercontent.com/${username}` — an undocumented username endpoint that happens to 200 (even for nonexistent users) but ignores the canonical URL we already fetched and is inconsistent with `DevMap`.

Fix reads `avatar_url` first, with a stable documented fallback, matching `DevMap`:
```js
const avatar = dev?.avatar_url || dev?.avatar || `https://github.com/${username}.png?size=80`;
```

Visual result is unchanged (same images); this is a correctness/robustness fix. Build passes.

Closes #37