### PR TITLE
feat(app): preserve active tab across reloads (#32)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -10,8 +10,22 @@ import BadgeGenerator from './pages/BadgeGenerator';
 import Register from './pages/Register';
 import Digest from './pages/Digest';
 
+const VALID_TABS = ['leaderboard', 'register', 'digest', 'map', 'about', 'evolution', 'badge'];
+const TAB_STORAGE_KEY = 'rankistan_active_tab';
+
+function getInitialTab() {
+  try {
+    // A deep-link hash (e.g. #username from a shared or badge link) should land on
+    // the leaderboard, so it takes precedence over any persisted tab.
+    if (window.location.hash.slice(1)) return 'leaderboard';
+    const saved = localStorage.getItem(TAB_STORAGE_KEY);
+    if (saved && VALID_TABS.includes(saved)) return saved;
+  } catch (e) { /* ignore storage/access errors */ }
+  return 'leaderboard';
+}
+
 function App() {
-  const [activeTab, setActiveTab] = useState('leaderboard');
+  const [activeTab, setActiveTab] = useState(getInitialTab);
   const [searchTerm, setSearchTerm] = useState('');
   const [badgePrefillUsername, setBadgePrefillUsername] = useState('');
 
@@ -27,6 +41,11 @@ function App() {
       badge: 'Rankistan | Badge Generator',
     };
     document.title = titles[activeTab] || 'Rankistan';
+  }, [activeTab]);
+
+  // Persist the active tab so a page reload restores it (#32)
+  React.useEffect(() => {
+    try { localStorage.setItem(TAB_STORAGE_KEY, activeTab); } catch (e) { /* ignore */ }
   }, [activeTab]);
 
   const handleChangeTab = useCallback((tab) => {


### PR DESCRIPTION
Reloading previously reset the app to the Leaderboard tab. Now `activeTab` initializes from `localStorage` (validated against the 7 known tabs) and is persisted on change, so a refresh keeps you where you were.

A deep-link hash (`#username`) takes precedence over the persisted tab, so shared links and the badge verification links (#52) still land on the leaderboard — keeping this compatible with the future deep-link work (#42).

Single-file change to `App.jsx`. Build passes; previewed locally (tab persists on reload; `#username` still lands on leaderboard).

Closes #32