### PR TITLE
fix(groq): replace decommissioned llama-3.3-70b with gpt-oss-120b

### DIFF
--- a/cloudflare/worker.js
+++ b/cloudflare/worker.js
@@ -1,8 +1,10 @@
 const GROQ_API_URL = 'https://api.groq.com/openai/v1/chat/completions';
-const GROQ_MODEL = 'llama-3.3-70b-versatile';
-const GROQ_MAX_TOKENS = 120;
+const GROQ_MODEL = 'openai/gpt-oss-120b';
+const GROQ_MAX_COMPLETION_TOKENS = 800;
 const GROQ_TEMPERATURE = 0.5;
-const GROQ_TIMEOUT_MS = 15000;
+const GROQ_REASONING_EFFORT = 'low';
+const GROQ_INCLUDE_REASONING = false;
+const GROQ_TIMEOUT_MS = 25000;
 const MIN_SUMMARY_LENGTH = 30;
 const MAX_SUMMARY_LENGTH = 400;
 const RATE_LIMIT_WINDOW_MS = 60 * 1000;
@@ -262,8 +264,10 @@ async function callGroqOnce(dev, apiKey) {
       },
       body: JSON.stringify({
         model: GROQ_MODEL,
-        max_tokens: GROQ_MAX_TOKENS,
+        max_completion_tokens: GROQ_MAX_COMPLETION_TOKENS,
         temperature: GROQ_TEMPERATURE,
+        reasoning_effort: GROQ_REASONING_EFFORT,
+        include_reasoning: GROQ_INCLUDE_REASONING,
         messages: [
           { role: 'system', content: SYSTEM_PROMPT },
           { role: 'user', content: buildUserPrompt(dev) }

--- a/scripts/generate-digest.js
+++ b/scripts/generate-digest.js
@@ -5,10 +5,12 @@ import { fileURLToPath } from 'node:url';
 const GROQ_KEY_SLOTS = 8;
 
 const GROQ_API_URL = 'https://api.groq.com/openai/v1/chat/completions';
-const GROQ_MODEL = 'llama-3.3-70b-versatile';
-const GROQ_MAX_TOKENS = 600;
+const GROQ_MODEL = 'openai/gpt-oss-120b';
+const GROQ_MAX_COMPLETION_TOKENS = 1400;
 const GROQ_TEMPERATURE = 0.7;
-const GROQ_TIMEOUT_MS = 30000;
+const GROQ_REASONING_EFFORT = 'low';
+const GROQ_INCLUDE_REASONING = false;
+const GROQ_TIMEOUT_MS = 45000;
 const GROQ_RETRY_DELAY_MS = 10000;
 const MIN_VALID_DIGEST_LENGTH = 100;
 const MAX_REPOS_FOR_PROMPT = 40;
@@ -169,8 +171,10 @@ async function callGroqDigest(repos, apiKey) {
       },
       body: JSON.stringify({
         model: GROQ_MODEL,
-        max_tokens: GROQ_MAX_TOKENS,
+        max_completion_tokens: GROQ_MAX_COMPLETION_TOKENS,
         temperature: GROQ_TEMPERATURE,
+        reasoning_effort: GROQ_REASONING_EFFORT,
+        include_reasoning: GROQ_INCLUDE_REASONING,
         messages: [
           { role: 'system', content: SYSTEM_PROMPT },
           { role: 'user', content: userPrompt }


### PR DESCRIPTION
Fixes the dead `/api/dev-summary` endpoint. Refs #70.

## Problem

`llama-3.3-70b-versatile` was shut down on Groq on **2026-08-16**. The live endpoint has been failing since:

```
POST https://rankistan-summary-api.academics-ali.workers.dev/api/dev-summary
→ 502 {"error":"Failed to generate summary."}
```

The model ID was hardcoded in two places: `cloudflare/worker.js:2` and `scripts/generate-digest.js:8`.

## Model choice

Issue #70 suggested `openai/gpt-oss-120b` or `qwen/qwen3.6-27b`. This PR uses **`openai/gpt-oss-120b`**, because `qwen/qwen3.6-27b` is preview-tier and Groq documents preview models as *"not for use in production environments as they may be discontinued at short notice"* — which would set up a repeat of this same outage.

Current Groq production text models are only `openai/gpt-oss-120b` and `openai/gpt-oss-20b`.

## Why this isn't a one-line swap

`gpt-oss-120b` is a reasoning model, and its reasoning tokens draw from the same completion budget as the answer. At the old `max_tokens: 120`, reasoning could consume the entire budget and return empty or truncated `content`, which `validateSummary` rejects — a 502 all over again, just with a different cause. So:

| Change | Worker | Digest script |
|---|---|---|
| `max_tokens` → `max_completion_tokens` | 120 → 800 | 600 → 1400 |
| `reasoning_effort` | `'low'` | `'low'` |
| `include_reasoning` | `false` | `false` |
| Timeout | 15s → 25s | 30s → 45s |

`MAX_SUMMARY_LENGTH` (400) still truncates the visible output, so the larger budget is headroom for reasoning, not longer summaries. `reasoning_effort` on gpt-oss accepts only `low`/`medium`/`high` — unlike qwen, reasoning cannot be switched off.

## Verification status

- ✅ Both files pass `node --check`
- ✅ No remaining references to the dead model or the old `GROQ_MAX_TOKENS`
- ✅ Model ID and parameter support confirmed against Groq's current docs
- ⚠️ **Not yet exercised against the live Groq API** — no Groq key was available in the working environment. A harness that invokes the real worker `fetch` handler was written and confirmed to reach Groq (it surfaced a genuine `401` with a dummy key), but the success path is unverified.

**This does not restore production on merge.** The Worker must be redeployed separately with `npm run cf:deploy`. After deploying, confirm with:

```bash
curl -s -X POST https://rankistan-summary-api.academics-ali.workers.dev/api/dev-summary \
  -H "Content-Type: application/json" -H "Origin: https://rankistan.dev" \
  -d '{"dev":{"username":"torvalds","name":"Linus","bio":"kernel","total_stars":100,"public_repos":10,"followers":100,"events_30d":50,"top_languages":["C"],"location":"Portland"}}'
```

## Not addressed

No model fallback chain. A `400 model_decommissioned` still isn't retryable under `shouldTryNextKey`, so the next deprecation fails the same way rather than degrading. Worth a follow-up before closing #70 entirely.
