### PR TITLE
fix(heatmap): stop proxying and caching upstream error cards

### DIFF
--- a/cloudflare/worker.js
+++ b/cloudflare/worker.js
@@ -319,7 +319,13 @@ async function callGroqWithKeyFallback(dev, apiKeys) {
 const HEATMAP_UPSTREAM = 'https://github-readme-activity-graph.vercel.app/graph';
 const HEATMAP_COLOR = '50b85e';
 const HEATMAP_BG = '10141a';
+const HEATMAP_CACHE_SECONDS = 3600;
+const HEATMAP_ERROR_MARKERS = ["Can't fetch any contribution", 'Please check your username'];
 const GITHUB_USERNAME_RE = /^[a-z0-9](?:[a-z0-9-]{0,37}[a-z0-9])?$/i;
+
+function isHeatmapErrorCard(svg) {
+  return HEATMAP_ERROR_MARKERS.some((marker) => svg.includes(marker));
+}
 
 function buildHeatmapUpstreamUrl(username) {
   const params = new URLSearchParams({
@@ -347,26 +353,63 @@ async function handleHeatmapRequest(request, env) {
     return jsonResponse({ error: 'Invalid username.' }, 400, corsOrigin);
   }
 
+  const upstreamUrl = buildHeatmapUpstreamUrl(username);
+  const cache = typeof caches === 'undefined' ? null : caches.default;
+  const cacheKey = new Request(upstreamUrl, { method: 'GET' });
+
   try {
-    const upstream = await fetch(buildHeatmapUpstreamUrl(username), {
-      cf: { cacheTtl: 3600 }
-    });
+    const cached = cache ? await cache.match(cacheKey) : null;
+    if (cached) {
+      const cachedSvg = await cached.text();
+
+      if (!isHeatmapErrorCard(cachedSvg)) {
+        return new Response(cachedSvg, {
+          headers: {
+            ...buildCorsHeaders(corsOrigin),
+            'Content-Type': cached.headers.get('Content-Type') || 'image/svg+xml',
+            'Cache-Control': `public, max-age=${HEATMAP_CACHE_SECONDS}`
+          }
+        });
+      }
+
+      await cache.delete(cacheKey);
+    }
+
+    const upstream = await fetch(upstreamUrl);
 
     if (!upstream.ok) {
       throw new Error(`Heatmap upstream returned ${upstream.status}.`);
     }
 
-    const body = await upstream.arrayBuffer();
-    return new Response(body, {
+    const svg = await upstream.text();
+
+    if (isHeatmapErrorCard(svg)) {
+      throw new Error('Heatmap upstream returned an error card.');
+    }
+
+    const response = new Response(svg, {
       headers: {
         ...buildCorsHeaders(corsOrigin),
         'Content-Type': upstream.headers.get('Content-Type') || 'image/svg+xml',
-        'Cache-Control': 'public, max-age=3600'
+        'Cache-Control': `public, max-age=${HEATMAP_CACHE_SECONDS}`
       }
     });
+
+    if (cache) {
+      await cache.put(cacheKey, response.clone());
+    }
+
+    return response;
   } catch (error) {
     console.error(`Heatmap proxy failed for ${username}: ${error.message}`);
-    return jsonResponse({ error: 'Heatmap unavailable.' }, 502, corsOrigin);
+    return new Response(JSON.stringify({ error: 'Heatmap unavailable.' }), {
+      status: 502,
+      headers: {
+        ...buildCorsHeaders(corsOrigin),
+        'Content-Type': 'application/json',
+        'Cache-Control': 'no-store'
+      }
+    });
   }
 }
 


### PR DESCRIPTION
Fixes the `CONTRIBUTION_ACTIVITY` panel rendering *"Can't fetch any contribution. Please check your username 🙁"* and staying broken for an hour at a time.

## Root cause

`github-readme-activity-graph` serves its error card with **HTTP 200**, not an error status. `handleHeatmapRequest` only checked `upstream.ok`, so it:

1. Treated the error card as a valid image and proxied it through.
2. Cached it for an hour via *both* `Cache-Control: public, max-age=3600` and `cf: { cacheTtl: 3600 }`.

So one transient upstream hiccup became a pinned, hour-long outage for that username.

The frontend fallback in `DevCard.jsx` (`handleError` → `resolveHeatmapDirectUrl`) could never rescue it, because the `<img>` loaded *successfully* — it was a valid image that happened to depict an error message.

## Evidence

| Test | Result |
|---|---|
| Worker's exact upstream URL, direct, ×5 | ok — 17,822 bytes every time |
| Worker `/api/heatmap/NadirAliOfficial` ×3 | error card every time |
| Worker `/api/heatmap/torvalds` | ok — 19,793 bytes |
| All 8 upstream param combinations, direct | all ok |

Deterministic per-username with the parameters exonerated — a poisoned cache entry, not upstream flakiness.

## Changes

- `isHeatmapErrorCard()` detects the card by content.
- An error card is now a failure: **502 + `Cache-Control: no-store`**, so nothing gets pinned and the existing frontend fallback to the direct URL actually engages.
- Blanket `cf.cacheTtl` replaced with explicit Cache API writes that store **only validated successes**.
- Cached bodies are re-validated on read and purged if poisoned — `cf.cacheTtl` and `caches.default` share one cache, so pre-existing bad entries would otherwise still be served and this fix would appear to do nothing.

## Verification

Deployed and confirmed live (version `ea8cae47-c880-49a7-b386-e831ad6d64e7`):

- `NadirAliOfficial` — previously stuck on the error card — now returns the real 17,822-byte graph, and the repeat call serves the freshly cached good copy. The purge path ran for real.
- `torvalds` still ok (19,792 bytes).
- Invalid username still `400`.
- `/api/dev-summary` unaffected.

Local suite against the real `fetch` handler:

```
case 1: live upstream, real username    4/4 PASS
case 2: error card w/ HTTP 200          3/3 PASS  -> 502, no-store
case 3: upstream HTTP 500               2/2 PASS  -> 502, no-store
case 4: invalid username                1/1 PASS  -> 400
```

## Notes

- Branched off `main`, so this is independent of #71 — both touch `cloudflare/worker.js` but in non-overlapping regions.
- Production currently runs this **plus** #71's model swap. Merging #71 aligns `main` with what's deployed.
- Dropping `cf.cacheTtl` means a cold cache now hits the upstream directly rather than Cloudflare's edge. The `max-age=3600` response header plus Cache API writes on success still shield it from repeat load, but if upstream rate-limiting becomes an issue, caching a short-lived negative result would be the next lever.
