### PR TITLE
chore: sync package-lock with the engines field

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,9 @@
         "tailwindcss": "^3.4.19",
         "vite": "^8.0.1",
         "vitest": "^4.1.7"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@alloc/quick-lru": {


### PR DESCRIPTION
Three generated lines: `npm ci` writes the `engines` constraint added in #74 into the lockfile root entry. Without this a clean install leaves the working tree dirty.