### PR TITLE
fix(worker): run both rate-limit layers; hold back the ESLint major

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,6 +17,14 @@ updates:
       # migration, not an automated PR.
       - dependency-name: tailwindcss
         update-types: [version-update:semver-major]
+      # ESLint 10 cannot be taken yet: eslint-plugin-jsx-a11y@6 peers on
+      # "eslint ^3 || ... || ^9", so bumping the major breaks `npm ci` with an
+      # ERESOLVE conflict. This was caught by CI on #80. Revisit once jsx-a11y
+      # ships v10 support, and bump eslint and @eslint/js together.
+      - dependency-name: eslint
+        update-types: [version-update:semver-major]
+      - dependency-name: "@eslint/js"
+        update-types: [version-update:semver-major]
 
   - package-ecosystem: github-actions
     directory: /

--- a/cloudflare/worker.js
+++ b/cloudflare/worker.js
@@ -231,16 +231,37 @@ async function isRateLimited(request, env) {
   const ip = getClientIp(request);
   const limiter = env?.SUMMARY_RATE_LIMITER;
 
+  // MEASURED IN PRODUCTION, NOT ASSUMED: the SUMMARY_RATE_LIMITER binding does
+  // not enforce here. It returns {"success":true} for every sequential request
+  // with a correct, stable key - verified by logging the raw result, and
+  // confirmed by dropping the configured limit to 3 and still passing 10
+  // sequential requests. It rejected 7 of 40 *concurrent* requests, so it
+  // provides some coarse burst protection and nothing more.
+  //
+  // Both layers therefore run, and either can reject. They used to be
+  // primary-and-fallback, and because the binding never throws, the `return`
+  // inside the try made the in-isolate counter unreachable - so nothing at all
+  // caught a slow drip. Note isRateLimitedInIsolate() also *records* the
+  // request, so it must be called on every request, not only when the binding
+  // passes.
+  //
+  // This is still not a correct rate limiter: isolates are ephemeral, so a
+  // sequential attacker keeps landing on fresh ones with empty state. That is
+  // the residue of #65 and needs a Durable Object to fix properly. What
+  // actually bounds abuse today is the username validation and the
+  // leaderboard-membership check below, not this.
+  const isolateLimited = isRateLimitedInIsolate(ip);
+
   if (limiter && typeof limiter.limit === 'function') {
     try {
       const { success } = await limiter.limit({ key: ip });
-      return !success;
+      return !success || isolateLimited;
     } catch (error) {
-      console.error('SUMMARY_RATE_LIMITER failed; falling back to in-isolate counter.', error);
+      console.error('SUMMARY_RATE_LIMITER failed; using the in-isolate counter alone.', error);
     }
   }
 
-  return isRateLimitedInIsolate(ip);
+  return isolateLimited;
 }
 
 function isRateLimitedInIsolate(ip) {


### PR DESCRIPTION
Two fixes, both from testing the deployed Worker rather than trusting it.

### The rate limiter does not enforce

I closed #65 saying the bypass was fixed. Production says otherwise:

| Test | Result |
|---|---|
| 30 sequential requests, clean window | **zero** 429s |
| Raw binding result, logged | `{"success":true}` every time, correct stable key |
| Limit dropped to 3, 10 sequential requests | **zero** 429s (deploy confirmed `3 requests/60s`) |
| 40 concurrent requests | 7 rejected |

So `SUMMARY_RATE_LIMITER` gives coarse burst protection and no sequential
enforcement. The comments now record that as measured fact rather than
asserting a guarantee.

Separately the two layers were primary-and-fallback, and since the binding never
throws, the `return` inside the `try` made the in-isolate counter **unreachable**
— so nothing caught a slow drip. Both now run and either can reject.

This still isn't a correct rate limiter and the code says so: isolates are
ephemeral, so a sequential attacker keeps landing on fresh ones. Fixing it needs
a Durable Object — a design decision, not a patch. **Reopening #65.**

What actually bounds abuse today is username validation plus the
leaderboard-membership check, both verified live (400 on a malformed handle, 404
on an unranked one).

### Hold back the ESLint major

#80 failed CI because it swept in `eslint 9 -> 10` while
`eslint-plugin-jsx-a11y@6` peers on `eslint ^9`, so `npm ci` dies with ERESOLVE.
That plugin is one I added, and my dependabot config held back Tailwind's major
but not ESLint's. Now ignored, with the revisit condition recorded.

The CI gate from #74 is what caught this — otherwise it would have been a merge
that broke every subsequent install.